### PR TITLE
Set index to last word of host names

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Note: replace PRIVATE_IP or PUBLIC_IP with tools-private-ip or tools-public-ip
 
 **Note: set the appropriate users for the images in the terraform variables, default is `root`**
 
-You can use the use the auto-generated ssh_config file to connect to the droplets by droplet name, e.g. `ssh <prefix>-rancheragent-0-all` or `ssh <prefix>-rancherserver` etc. To do so, you have two options:
+You can use the use the auto-generated ssh_config file to connect to the droplets by droplet name, e.g. `ssh <prefix>-rancheragent-all-0` or `ssh <prefix>-rancherserver` etc. To do so, you have two options:
 
 1. Add an `Include` directive at the top of the SSH config file in your home directory (`~/.ssh/config`) to include the ssh_config file at the location you have checked out the this repository, e.g. `Include ~/git/tf-do-rancher2/ssh_config`.
 

--- a/files/ssh_config_template
+++ b/files/ssh_config_template
@@ -4,35 +4,35 @@ Host ${prefix}-rancherserver
   StrictHostKeyChecking no
 
 %{ for index, ip in rancheragent-all ~}
-Host ${prefix}-rancheragent-${index}-all
+Host ${prefix}-rancheragent-all-${index}
   HostName ${ip}
   User ${user-agent}
   StrictHostKeyChecking no
 
 %{ endfor ~}
 %{ for index, ip in rancheragent-etcd ~}
-Host ${prefix}-rancheragent-${index}-etcd
+Host ${prefix}-rancheragent-etcd-${index}
   HostName ${ip}
   User ${user-agent}
   StrictHostKeyChecking no
 
 %{ endfor ~}
 %{ for index, ip in rancheragent-controlplane ~}
-Host ${prefix}-rancheragent-${index}-controlplane
+Host ${prefix}-rancheragent-controlplane-${index}
   HostName ${ip}
   User ${user-agent}
   StrictHostKeyChecking no
 
 %{ endfor ~}
 %{ for index, ip in rancheragent-worker ~}
-Host ${prefix}-rancheragent-${index}-worker
+Host ${prefix}-rancheragent-worker-${index}
   HostName ${ip}
   User ${user-agent}
   StrictHostKeyChecking no
 
 %{ endfor ~}
 %{ for index, ip in rancher-tools ~}
-Host ${prefix}-rancher-${index}-tools
+Host ${prefix}-rancher-tools-${index}
   HostName ${ip}
   User ${user-tools}
   StrictHostKeyChecking no

--- a/files/userdata_agent
+++ b/files/userdata_agent
@@ -65,7 +65,7 @@ while true; do
 done
 
 # Get role flags from hostname
-ROLEFLAG=`hostname | awk -F'-' '{ print $NF }'`
+ROLEFLAG=`hostname | awk -F'-' '{ print $(NF-1) }'`
 if [[ "$ROLEFLAG" == "all" ]]; then
   ROLEFLAG="all-roles"
 fi

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ resource "digitalocean_droplet" "rancherserver" {
 resource "digitalocean_droplet" "rancheragent-all" {
   count              = var.count_agent_all_nodes
   image              = var.image_agent
-  name               = "${var.prefix}-rancheragent-${count.index}-all"
+  name               = "${var.prefix}-rancheragent-all-${count.index}"
   private_networking = true
   region             = var.region_agent
   size               = var.all_size
@@ -148,7 +148,7 @@ resource "digitalocean_droplet" "rancheragent-all" {
 resource "digitalocean_droplet" "rancheragent-etcd" {
   count              = var.count_agent_etcd_nodes
   image              = var.image_agent
-  name               = "${var.prefix}-rancheragent-${count.index}-etcd"
+  name               = "${var.prefix}-rancheragent-etcd-${count.index}"
   private_networking = true
   region             = var.region_agent
   size               = var.etcd_size
@@ -159,7 +159,7 @@ resource "digitalocean_droplet" "rancheragent-etcd" {
 resource "digitalocean_droplet" "rancheragent-controlplane" {
   count              = var.count_agent_controlplane_nodes
   image              = var.image_agent
-  name               = "${var.prefix}-rancheragent-${count.index}-controlplane"
+  name               = "${var.prefix}-rancheragent-controlplane-${count.index}"
   private_networking = true
   region             = var.region_agent
   size               = var.controlplane_size
@@ -170,7 +170,7 @@ resource "digitalocean_droplet" "rancheragent-controlplane" {
 resource "digitalocean_droplet" "rancheragent-worker" {
   count              = var.count_agent_worker_nodes
   image              = var.image_agent
-  name               = "${var.prefix}-rancheragent-${count.index}-worker"
+  name               = "${var.prefix}-rancheragent-worker-${count.index}"
   private_networking = true
   region             = var.region_agent
   size               = var.worker_size
@@ -181,7 +181,7 @@ resource "digitalocean_droplet" "rancheragent-worker" {
 resource "digitalocean_droplet" "rancher-tools" {
   count              = var.count_tools_nodes
   image              = var.image_tools
-  name               = "${var.prefix}-rancher-${count.index}-tools"
+  name               = "${var.prefix}-rancher-tools-${count.index}"
   private_networking = true
   region             = var.region_agent
   size               = var.tools_size


### PR DESCRIPTION
It seems more logical to me to have node names of the format ${prefix}-<type>-<role>-${index}, so consistent 'categorisation' left to right from biggest to smallest.