### PR TITLE
Patch terraform.tfvars.example | set version

### DIFF
--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -8,7 +8,7 @@ admin_password = "admin"
 prefix = "myname"
 
 # rancher/rancher image tag to use
-rancher_version = "v2.2.6"
+rancher_version = "v2.5.2"
 
 # Rancher server audit log level (0-3)
 audit_level = 0


### PR DESCRIPTION
To use this repo with the latest supported Rancher version I propose to update `rancher_version` to `v2.5.2`