### PR TITLE
Version changes to `main.tf` & `terraform.tfvars.example`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ variable "prefix" {
 }
 
 variable "rancher_version" {
-  default = "v2.2.6"
+  default = "v2.5.2"
 }
 
 variable "audit_level" {

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -8,7 +8,7 @@ admin_password = "admin"
 prefix = "myname"
 
 # rancher/rancher image tag to use
-rancher_version = "v2.2.6"
+rancher_version = "v2.5.2"
 
 # Rancher server audit log level (0-3)
 audit_level = 0


### PR DESCRIPTION
I propose to change the `rancher_version` vars in both files to the latest stable and supported release of `v2.5.2`